### PR TITLE
Add explicit dependency on cstdint

### DIFF
--- a/deps/libmediasoupclient/include/Logger.hpp
+++ b/deps/libmediasoupclient/include/Logger.hpp
@@ -44,6 +44,7 @@
 #define MSC_LOGGER_HPP
 
 #include <cstdio>  // std::snprintf(), std::fprintf(), stdout, stderr
+#include <cstdint> // uint8_t
 #include <cstdlib> // std::abort()
 #include <cstring>
 


### PR DESCRIPTION
On some platforms like Ubuntu, uint8_t is not found by default, so add explicit dependency on cstdint where it is defined for c++11.