### PR TITLE
upgrade to webrtc m120-6099。

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,12 @@ set(broadcaster_VERSION_MAJOR 0)
 set(broadcaster_VERSION_MINOR 1)
 
 # C++ standard requirements.
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -v -Wall -stdlib=libc++")		# v:显示详细信息  Wall:启用所有编译器警告
+set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g")						# debug开启调试, cmake -DCMAKE_BUILD_TYPE=Debug /path/to/source
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g")
+# set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -g")				# release 
 
 message("\n=========== mediasoup-broadcaster-demo Build Configuration ===========\n")
 message(STATUS "LIBWEBRTC_INCLUDE_PATH : " ${LIBWEBRTC_INCLUDE_PATH})
@@ -52,8 +56,8 @@ include(FetchContent)
 message(STATUS "\nFetching mediasoupclient...\n")
 FetchContent_Declare(
   mediasoupclient
-  GIT_REPOSITORY https://github.com/versatica/libmediasoupclient.git
-  GIT_TAG v3
+  GIT_REPOSITORY git@github.com:janreyho/libmediasoupclient.git
+  GIT_TAG m120
 )
 FetchContent_MakeAvailable(mediasoupclient)
 

--- a/deps/libwebrtc/media/base/fake_frame_source.cc
+++ b/deps/libwebrtc/media/base/fake_frame_source.cc
@@ -52,7 +52,7 @@ webrtc::VideoFrame FakeFrameSource::GetFrameRotationApplied() {
     case webrtc::kVideoRotation_270:
       return GetFrame(height_, width_, webrtc::kVideoRotation_0, interval_us_);
   }
-  RTC_NOTREACHED() << "Invalid rotation value: " << static_cast<int>(rotation_);
+  RTC_DCHECK_NOTREACHED() << "Invalid rotation value: " << static_cast<int>(rotation_);
   // Without this return, the Windows Visual Studio compiler complains
   // "not all control paths return a value".
   return GetFrame();

--- a/deps/libwebrtc/pc/test/fake_audio_capture_module.cc
+++ b/deps/libwebrtc/pc/test/fake_audio_capture_module.cc
@@ -12,11 +12,13 @@
 
 #include <string.h>
 
+#include "api/make_ref_counted.h"
+#include "api/units/time_delta.h"
 #include "rtc_base/checks.h"
-#include "rtc_base/location.h"
-#include "rtc_base/ref_counted_object.h"
 #include "rtc_base/thread.h"
 #include "rtc_base/time_utils.h"
+
+using ::webrtc::TimeDelta;
 
 // Audio sample value that is high enough that it doesn't occur naturally when
 // frames are being faked. E.g. NetEq will not generate this large sample value
@@ -33,11 +35,6 @@ static const int kTotalDelayMs = 0;
 static const int kClockDriftMs = 0;
 static const uint32_t kMaxVolume = 14392;
 
-enum {
-  MSG_START_PROCESS,
-  MSG_RUN_PROCESS,
-};
-
 FakeAudioCaptureModule::FakeAudioCaptureModule()
     : audio_callback_(nullptr),
       recording_(false),
@@ -47,9 +44,7 @@ FakeAudioCaptureModule::FakeAudioCaptureModule()
       current_mic_level_(kMaxVolume),
       started_(false),
       next_frame_time_(0),
-      frames_received_(0) {
-  process_thread_checker_.Detach();
-}
+      frames_received_(0) {}
 
 FakeAudioCaptureModule::~FakeAudioCaptureModule() {
   if (process_thread_) {
@@ -72,7 +67,7 @@ int FakeAudioCaptureModule::frames_received() const {
 
 int32_t FakeAudioCaptureModule::ActiveAudioLayer(
     AudioLayer* /*audio_layer*/) const {
-  RTC_NOTREACHED();
+  RTC_DCHECK_NOTREACHED();
   return 0;
 }
 
@@ -94,17 +89,17 @@ int32_t FakeAudioCaptureModule::Terminate() {
 }
 
 bool FakeAudioCaptureModule::Initialized() const {
-  RTC_NOTREACHED();
+  RTC_DCHECK_NOTREACHED();
   return 0;
 }
 
 int16_t FakeAudioCaptureModule::PlayoutDevices() {
-  RTC_NOTREACHED();
+  RTC_DCHECK_NOTREACHED();
   return 0;
 }
 
 int16_t FakeAudioCaptureModule::RecordingDevices() {
-  RTC_NOTREACHED();
+  RTC_DCHECK_NOTREACHED();
   return 0;
 }
 
@@ -112,7 +107,7 @@ int32_t FakeAudioCaptureModule::PlayoutDeviceName(
     uint16_t /*index*/,
     char /*name*/[webrtc::kAdmMaxDeviceNameSize],
     char /*guid*/[webrtc::kAdmMaxGuidSize]) {
-  RTC_NOTREACHED();
+  RTC_DCHECK_NOTREACHED();
   return 0;
 }
 
@@ -120,7 +115,7 @@ int32_t FakeAudioCaptureModule::RecordingDeviceName(
     uint16_t /*index*/,
     char /*name*/[webrtc::kAdmMaxDeviceNameSize],
     char /*guid*/[webrtc::kAdmMaxGuidSize]) {
-  RTC_NOTREACHED();
+  RTC_DCHECK_NOTREACHED();
   return 0;
 }
 
@@ -150,7 +145,7 @@ int32_t FakeAudioCaptureModule::SetRecordingDevice(
 }
 
 int32_t FakeAudioCaptureModule::PlayoutIsAvailable(bool* /*available*/) {
-  RTC_NOTREACHED();
+  RTC_DCHECK_NOTREACHED();
   return 0;
 }
 
@@ -164,7 +159,7 @@ bool FakeAudioCaptureModule::PlayoutIsInitialized() const {
 }
 
 int32_t FakeAudioCaptureModule::RecordingIsAvailable(bool* /*available*/) {
-  RTC_NOTREACHED();
+  RTC_DCHECK_NOTREACHED();
   return 0;
 }
 
@@ -241,7 +236,7 @@ int32_t FakeAudioCaptureModule::InitSpeaker() {
 }
 
 bool FakeAudioCaptureModule::SpeakerIsInitialized() const {
-  RTC_NOTREACHED();
+  RTC_DCHECK_NOTREACHED();
   return 0;
 }
 
@@ -251,40 +246,40 @@ int32_t FakeAudioCaptureModule::InitMicrophone() {
 }
 
 bool FakeAudioCaptureModule::MicrophoneIsInitialized() const {
-  RTC_NOTREACHED();
+  RTC_DCHECK_NOTREACHED();
   return 0;
 }
 
 int32_t FakeAudioCaptureModule::SpeakerVolumeIsAvailable(bool* /*available*/) {
-  RTC_NOTREACHED();
+  RTC_DCHECK_NOTREACHED();
   return 0;
 }
 
 int32_t FakeAudioCaptureModule::SetSpeakerVolume(uint32_t /*volume*/) {
-  RTC_NOTREACHED();
+  RTC_DCHECK_NOTREACHED();
   return 0;
 }
 
 int32_t FakeAudioCaptureModule::SpeakerVolume(uint32_t* /*volume*/) const {
-  RTC_NOTREACHED();
+  RTC_DCHECK_NOTREACHED();
   return 0;
 }
 
 int32_t FakeAudioCaptureModule::MaxSpeakerVolume(
     uint32_t* /*max_volume*/) const {
-  RTC_NOTREACHED();
+  RTC_DCHECK_NOTREACHED();
   return 0;
 }
 
 int32_t FakeAudioCaptureModule::MinSpeakerVolume(
     uint32_t* /*min_volume*/) const {
-  RTC_NOTREACHED();
+  RTC_DCHECK_NOTREACHED();
   return 0;
 }
 
 int32_t FakeAudioCaptureModule::MicrophoneVolumeIsAvailable(
     bool* /*available*/) {
-  RTC_NOTREACHED();
+  RTC_DCHECK_NOTREACHED();
   return 0;
 }
 
@@ -308,37 +303,37 @@ int32_t FakeAudioCaptureModule::MaxMicrophoneVolume(
 
 int32_t FakeAudioCaptureModule::MinMicrophoneVolume(
     uint32_t* /*min_volume*/) const {
-  RTC_NOTREACHED();
+  RTC_DCHECK_NOTREACHED();
   return 0;
 }
 
 int32_t FakeAudioCaptureModule::SpeakerMuteIsAvailable(bool* /*available*/) {
-  RTC_NOTREACHED();
+  RTC_DCHECK_NOTREACHED();
   return 0;
 }
 
 int32_t FakeAudioCaptureModule::SetSpeakerMute(bool /*enable*/) {
-  RTC_NOTREACHED();
+  RTC_DCHECK_NOTREACHED();
   return 0;
 }
 
 int32_t FakeAudioCaptureModule::SpeakerMute(bool* /*enabled*/) const {
-  RTC_NOTREACHED();
+  RTC_DCHECK_NOTREACHED();
   return 0;
 }
 
 int32_t FakeAudioCaptureModule::MicrophoneMuteIsAvailable(bool* /*available*/) {
-  RTC_NOTREACHED();
+  RTC_DCHECK_NOTREACHED();
   return 0;
 }
 
 int32_t FakeAudioCaptureModule::SetMicrophoneMute(bool /*enable*/) {
-  RTC_NOTREACHED();
+  RTC_DCHECK_NOTREACHED();
   return 0;
 }
 
 int32_t FakeAudioCaptureModule::MicrophoneMute(bool* /*enabled*/) const {
-  RTC_NOTREACHED();
+  RTC_DCHECK_NOTREACHED();
   return 0;
 }
 
@@ -357,7 +352,7 @@ int32_t FakeAudioCaptureModule::SetStereoPlayout(bool /*enable*/) {
 }
 
 int32_t FakeAudioCaptureModule::StereoPlayout(bool* /*enabled*/) const {
-  RTC_NOTREACHED();
+  RTC_DCHECK_NOTREACHED();
   return 0;
 }
 
@@ -376,7 +371,7 @@ int32_t FakeAudioCaptureModule::SetStereoRecording(bool enable) {
 }
 
 int32_t FakeAudioCaptureModule::StereoRecording(bool* /*enabled*/) const {
-  RTC_NOTREACHED();
+  RTC_DCHECK_NOTREACHED();
   return 0;
 }
 
@@ -384,21 +379,6 @@ int32_t FakeAudioCaptureModule::PlayoutDelay(uint16_t* delay_ms) const {
   // No delay since audio frames are dropped.
   *delay_ms = 0;
   return 0;
-}
-
-void FakeAudioCaptureModule::OnMessage(rtc::Message* msg) {
-  switch (msg->message_id) {
-    case MSG_START_PROCESS:
-      StartProcessP();
-      break;
-    case MSG_RUN_PROCESS:
-      ProcessFrameP();
-      break;
-    default:
-      // All existing messages should be caught. Getting here should never
-      // happen.
-      RTC_NOTREACHED();
-  }
 }
 
 bool FakeAudioCaptureModule::Initialize() {
@@ -444,7 +424,7 @@ void FakeAudioCaptureModule::UpdateProcessing(bool start) {
       process_thread_ = rtc::Thread::Create();
       process_thread_->Start();
     }
-    process_thread_->Post(RTC_FROM_HERE, this, MSG_START_PROCESS);
+    process_thread_->PostTask([this] { StartProcessP(); });
   } else {
     if (process_thread_) {
       process_thread_->Stop();
@@ -490,7 +470,8 @@ void FakeAudioCaptureModule::ProcessFrameP() {
   const int64_t current_time = rtc::TimeMillis();
   const int64_t wait_time =
       (next_frame_time_ > current_time) ? next_frame_time_ - current_time : 0;
-  process_thread_->PostDelayed(RTC_FROM_HERE, wait_time, this, MSG_RUN_PROCESS);
+  process_thread_->PostDelayedTask([this] { ProcessFrameP(); },
+                                   TimeDelta::Millis(wait_time));
 }
 
 void FakeAudioCaptureModule::ReceiveFrameP() {
@@ -506,7 +487,7 @@ void FakeAudioCaptureModule::ReceiveFrameP() {
                                         kNumberOfChannels, kSamplesPerSecond,
                                         rec_buffer_, nSamplesOut,
                                         &elapsed_time_ms, &ntp_time_ms) != 0) {
-    RTC_NOTREACHED();
+    RTC_DCHECK_NOTREACHED();
   }
   RTC_CHECK(nSamplesOut == kNumberSamples);
 
@@ -532,7 +513,7 @@ void FakeAudioCaptureModule::SendFrameP() {
           send_buffer_, kNumberSamples, kNumberBytesPerSample,
           kNumberOfChannels, kSamplesPerSecond, kTotalDelayMs, kClockDriftMs,
           current_mic_level, key_pressed, current_mic_level) != 0) {
-    RTC_NOTREACHED();
+    RTC_DCHECK_NOTREACHED();
   }
   current_mic_level_ = current_mic_level;
 }

--- a/deps/libwebrtc/pc/test/fake_audio_capture_module.h
+++ b/deps/libwebrtc/pc/test/fake_audio_capture_module.h
@@ -29,18 +29,14 @@
 #include "api/sequence_checker.h"
 #include "modules/audio_device/include/audio_device.h"
 #include "modules/audio_device/include/audio_device_defines.h"
-#include "rtc_base/message_handler.h"
 #include "rtc_base/synchronization/mutex.h"
-#include "rtc_base/thread.h"
 #include "rtc_base/thread_annotations.h"
-#include "rtc_base/thread_message.h"
 
 namespace rtc {
 class Thread;
 }  // namespace rtc
 
-class FakeAudioCaptureModule : public webrtc::AudioDeviceModule,
-                               public rtc::MessageHandlerAutoCleanup {
+class FakeAudioCaptureModule : public webrtc::AudioDeviceModule {
  public:
   typedef uint16_t Sample;
 
@@ -140,6 +136,10 @@ class FakeAudioCaptureModule : public webrtc::AudioDeviceModule,
   int32_t EnableBuiltInNS(bool enable) override { return -1; }
 
   int32_t GetPlayoutUnderrunCount() const override { return -1; }
+
+  absl::optional<webrtc::AudioDeviceModule::Stats> GetStats() const override {
+    return webrtc::AudioDeviceModule::Stats();
+  }
 #if defined(WEBRTC_IOS)
   int GetPlayoutAudioParameters(
       webrtc::AudioParameters* params) const override {
@@ -151,9 +151,6 @@ class FakeAudioCaptureModule : public webrtc::AudioDeviceModule,
 #endif  // WEBRTC_IOS
 
   // End of functions inherited from webrtc::AudioDeviceModule.
-
-  // The following function is inherited from rtc::MessageHandler.
-  void OnMessage(rtc::Message* msg) override;
 
  protected:
   // The constructor is protected because the class needs to be created as a
@@ -232,7 +229,8 @@ class FakeAudioCaptureModule : public webrtc::AudioDeviceModule,
   // Protects variables that are accessed from process_thread_ and
   // the main thread.
   mutable webrtc::Mutex mutex_;
-  webrtc::SequenceChecker process_thread_checker_;
+  webrtc::SequenceChecker process_thread_checker_{
+      webrtc::SequenceChecker::kDetached};
 };
 
 #endif  // PC_TEST_FAKE_AUDIO_CAPTURE_MODULE_H_

--- a/deps/libwebrtc/pc/test/frame_generator_capturer_video_track_source.h
+++ b/deps/libwebrtc/pc/test/frame_generator_capturer_video_track_source.h
@@ -64,9 +64,15 @@ class FrameGeneratorCapturerVideoTrackSource : public VideoTrackSource {
 
   ~FrameGeneratorCapturerVideoTrackSource() = default;
 
-  void Start() { SetState(kLive); }
+  void Start() {
+    SetState(kLive);
+    video_capturer_->Start();
+  }
 
-  void Stop() { SetState(kMuted); }
+  void Stop() {
+    SetState(kMuted);
+    video_capturer_->Stop();
+  }
 
   bool is_screencast() const override { return is_screencast_; }
 

--- a/deps/libwebrtc/rtc_base/task_queue_for_test.h
+++ b/deps/libwebrtc/rtc_base/task_queue_for_test.h
@@ -13,27 +13,29 @@
 
 #include <utility>
 
+#include "absl/cleanup/cleanup.h"
 #include "absl/strings/string_view.h"
+#include "api/function_view.h"
 #include "api/task_queue/task_queue_base.h"
 #include "rtc_base/checks.h"
 #include "rtc_base/event.h"
-#include "rtc_base/location.h"
 #include "rtc_base/task_queue.h"
-#include "rtc_base/task_utils/to_queued_task.h"
 #include "rtc_base/thread_annotations.h"
 
 namespace webrtc {
 
-template <typename Closure>
-void SendTask(rtc::Location loc, TaskQueueBase* task_queue, Closure&& task) {
-  RTC_CHECK(!task_queue->IsCurrent())
-      << "Called SendTask to a queue from the same queue at " << loc.ToString();
+inline void SendTask(TaskQueueBase* task_queue,
+                     rtc::FunctionView<void()> task) {
+  if (task_queue->IsCurrent()) {
+    task();
+    return;
+  }
+
   rtc::Event event;
-  task_queue->PostTask(
-      ToQueuedTask(std::forward<Closure>(task), [&event] { event.Set(); }));
-  RTC_CHECK(event.Wait(/*give_up_after_ms=*/rtc::Event::kForever,
-                       /*warn_after_ms=*/10'000))
-      << "Waited too long at " << loc.ToString();
+  absl::Cleanup cleanup = [&event] { event.Set(); };
+  task_queue->PostTask([task, cleanup = std::move(cleanup)] { task(); });
+  RTC_CHECK(event.Wait(/*give_up_after=*/rtc::Event::kForever,
+                       /*warn_after=*/TimeDelta::Seconds(10)));
 }
 
 class RTC_LOCKABLE TaskQueueForTest : public rtc::TaskQueue {
@@ -47,32 +49,17 @@ class RTC_LOCKABLE TaskQueueForTest : public rtc::TaskQueue {
 
   // A convenience, test-only method that blocks the current thread while
   // a task executes on the task queue.
-  // This variant is specifically for posting custom QueuedTask derived
-  // implementations that tests do not want to pass ownership of over to the
-  // task queue (i.e. the Run() method always returns `false`.).
-  template <class Closure>
-  void SendTask(Closure* task) {
-    RTC_CHECK(!IsCurrent());
-    rtc::Event event;
-    PostTask(ToQueuedTask(
-        [&task] { RTC_CHECK_EQ(false, static_cast<QueuedTask*>(task)->Run()); },
-        [&event] { event.Set(); }));
-    event.Wait(rtc::Event::kForever);
-  }
-
-  // A convenience, test-only method that blocks the current thread while
-  // a task executes on the task queue.
-  template <class Closure>
-  void SendTask(Closure&& task, rtc::Location loc) {
-    ::webrtc::SendTask(loc, Get(), std::forward<Closure>(task));
+  void SendTask(rtc::FunctionView<void()> task) {
+    ::webrtc::SendTask(Get(), task);
   }
 
   // Wait for the completion of all tasks posted prior to the
   // WaitForPreviouslyPostedTasks() call.
   void WaitForPreviouslyPostedTasks() {
+    RTC_DCHECK(!Get()->IsCurrent());
     // Post an empty task on the queue and wait for it to finish, to ensure
     // that all already posted tasks on the queue get executed.
-    SendTask([]() {}, RTC_FROM_HERE);
+    SendTask([]() {});
   }
 };
 

--- a/deps/libwebrtc/test/frame_generator.cc
+++ b/deps/libwebrtc/test/frame_generator.cc
@@ -45,6 +45,12 @@ void SquareGenerator::ChangeResolution(size_t width, size_t height) {
   RTC_CHECK(height_ > 0);
 }
 
+FrameGeneratorInterface::Resolution SquareGenerator::GetResolution() const {
+  MutexLock lock(&mutex_);
+  return {.width = static_cast<size_t>(width_),
+          .height = static_cast<size_t>(height_)};
+}
+
 rtc::scoped_refptr<I420Buffer> SquareGenerator::CreateI420Buffer(int width,
                                                                  int height) {
   rtc::scoped_refptr<I420Buffer> buffer(I420Buffer::Create(width, height));
@@ -82,7 +88,7 @@ FrameGeneratorInterface::VideoFrameData SquareGenerator::NextFrame() {
       break;
     }
     default:
-      RTC_NOTREACHED() << "The given output format is not supported.";
+      RTC_DCHECK_NOTREACHED() << "The given output format is not supported.";
   }
 
   for (const auto& square : squares_)
@@ -205,6 +211,76 @@ bool YuvFileGenerator::ReadNextFrame() {
   return frame_index_ != prev_frame_index || file_index_ != prev_file_index;
 }
 
+FrameGeneratorInterface::Resolution YuvFileGenerator::GetResolution() const {
+  return {.width = width_, .height = height_};
+}
+
+NV12FileGenerator::NV12FileGenerator(std::vector<FILE*> files,
+                                     size_t width,
+                                     size_t height,
+                                     int frame_repeat_count)
+    : file_index_(0),
+      frame_index_(std::numeric_limits<size_t>::max()),
+      files_(files),
+      width_(width),
+      height_(height),
+      frame_size_(CalcBufferSize(VideoType::kNV12,
+                                 static_cast<int>(width_),
+                                 static_cast<int>(height_))),
+      frame_buffer_(new uint8_t[frame_size_]),
+      frame_display_count_(frame_repeat_count),
+      current_display_count_(0) {
+  RTC_DCHECK_GT(width, 0);
+  RTC_DCHECK_GT(height, 0);
+  RTC_DCHECK_GT(frame_repeat_count, 0);
+}
+
+NV12FileGenerator::~NV12FileGenerator() {
+  for (FILE* file : files_)
+    fclose(file);
+}
+
+FrameGeneratorInterface::VideoFrameData NV12FileGenerator::NextFrame() {
+  // Empty update by default.
+  VideoFrame::UpdateRect update_rect{0, 0, 0, 0};
+  if (current_display_count_ == 0) {
+    const bool got_new_frame = ReadNextFrame();
+    // Full update on a new frame from file.
+    if (got_new_frame) {
+      update_rect = VideoFrame::UpdateRect{0, 0, static_cast<int>(width_),
+                                           static_cast<int>(height_)};
+    }
+  }
+  if (++current_display_count_ >= frame_display_count_)
+    current_display_count_ = 0;
+
+  return VideoFrameData(last_read_buffer_, update_rect);
+}
+
+FrameGeneratorInterface::Resolution NV12FileGenerator::GetResolution() const {
+  return {.width = width_, .height = height_};
+}
+
+bool NV12FileGenerator::ReadNextFrame() {
+  size_t prev_frame_index = frame_index_;
+  size_t prev_file_index = file_index_;
+  last_read_buffer_ = test::ReadNV12Buffer(
+      static_cast<int>(width_), static_cast<int>(height_), files_[file_index_]);
+  ++frame_index_;
+  if (!last_read_buffer_) {
+    // No more frames to read in this file, rewind and move to next file.
+    rewind(files_[file_index_]);
+
+    frame_index_ = 0;
+    file_index_ = (file_index_ + 1) % files_.size();
+    last_read_buffer_ =
+        test::ReadNV12Buffer(static_cast<int>(width_),
+                             static_cast<int>(height_), files_[file_index_]);
+    RTC_CHECK(last_read_buffer_);
+  }
+  return frame_index_ != prev_frame_index || file_index_ != prev_file_index;
+}
+
 SlideGenerator::SlideGenerator(int width, int height, int frame_repeat_count)
     : width_(width),
       height_(height),
@@ -223,6 +299,11 @@ FrameGeneratorInterface::VideoFrameData SlideGenerator::NextFrame() {
     current_display_count_ = 0;
 
   return VideoFrameData(buffer_, absl::nullopt);
+}
+
+FrameGeneratorInterface::Resolution SlideGenerator::GetResolution() const {
+  return {.width = static_cast<size_t>(width_),
+          .height = static_cast<size_t>(height_)};
 }
 
 void SlideGenerator::GenerateNewFrame() {
@@ -326,6 +407,12 @@ ScrollingImageFrameGenerator::NextFrame() {
   prev_frame_not_scrolled_ = cur_frame_not_scrolled;
 
   return current_frame_;
+}
+
+FrameGeneratorInterface::Resolution
+ScrollingImageFrameGenerator::GetResolution() const {
+  return {.width = static_cast<size_t>(target_width_),
+          .height = static_cast<size_t>(target_height_)};
 }
 
 void ScrollingImageFrameGenerator::UpdateSourceFrame(size_t frame_num) {

--- a/deps/libwebrtc/test/frame_generator.h
+++ b/deps/libwebrtc/test/frame_generator.h
@@ -17,9 +17,11 @@
 #include "api/scoped_refptr.h"
 #include "api/test/frame_generator_interface.h"
 #include "api/video/i420_buffer.h"
+#include "api/video/nv12_buffer.h"
 #include "api/video/video_frame.h"
 #include "api/video/video_frame_buffer.h"
 #include "api/video/video_source_interface.h"
+#include "rtc_base/logging.h"
 #include "rtc_base/random.h"
 #include "rtc_base/synchronization/mutex.h"
 #include "system_wrappers/include/clock.h"
@@ -36,6 +38,9 @@ class SquareGenerator : public FrameGeneratorInterface {
 
   void ChangeResolution(size_t width, size_t height) override;
   VideoFrameData NextFrame() override;
+  Resolution GetResolution() const override;
+
+  absl::optional<int> fps() const override { return absl::nullopt; }
 
  private:
   rtc::scoped_refptr<I420Buffer> CreateI420Buffer(int width, int height);
@@ -57,7 +62,7 @@ class SquareGenerator : public FrameGeneratorInterface {
     const uint8_t yuv_a_;
   };
 
-  Mutex mutex_;
+  mutable Mutex mutex_;
   const OutputType type_;
   int width_ RTC_GUARDED_BY(&mutex_);
   int height_ RTC_GUARDED_BY(&mutex_);
@@ -75,8 +80,11 @@ class YuvFileGenerator : public FrameGeneratorInterface {
 
   VideoFrameData NextFrame() override;
   void ChangeResolution(size_t width, size_t height) override {
-    RTC_NOTREACHED();
+    RTC_LOG(LS_WARNING) << "YuvFileGenerator::ChangeResolution not implemented";
   }
+  Resolution GetResolution() const override;
+
+  absl::optional<int> fps() const override { return absl::nullopt; }
 
  private:
   // Returns true if the new frame was loaded.
@@ -95,6 +103,41 @@ class YuvFileGenerator : public FrameGeneratorInterface {
   rtc::scoped_refptr<I420Buffer> last_read_buffer_;
 };
 
+class NV12FileGenerator : public FrameGeneratorInterface {
+ public:
+  NV12FileGenerator(std::vector<FILE*> files,
+                    size_t width,
+                    size_t height,
+                    int frame_repeat_count);
+
+  ~NV12FileGenerator();
+
+  VideoFrameData NextFrame() override;
+  void ChangeResolution(size_t width, size_t height) override {
+    RTC_LOG(LS_WARNING)
+        << "NV12FileGenerator::ChangeResolution not implemented";
+  }
+  Resolution GetResolution() const override;
+
+  absl::optional<int> fps() const override { return absl::nullopt; }
+
+ private:
+  // Returns true if the new frame was loaded.
+  // False only in case of a single file with a single frame in it.
+  bool ReadNextFrame();
+
+  size_t file_index_;
+  size_t frame_index_;
+  const std::vector<FILE*> files_;
+  const size_t width_;
+  const size_t height_;
+  const size_t frame_size_;
+  const std::unique_ptr<uint8_t[]> frame_buffer_;
+  const int frame_display_count_;
+  int current_display_count_;
+  rtc::scoped_refptr<NV12Buffer> last_read_buffer_;
+};
+
 // SlideGenerator works similarly to YuvFileGenerator but it fills the frames
 // with randomly sized and colored squares instead of reading their content
 // from files.
@@ -104,8 +147,11 @@ class SlideGenerator : public FrameGeneratorInterface {
 
   VideoFrameData NextFrame() override;
   void ChangeResolution(size_t width, size_t height) override {
-    RTC_NOTREACHED();
+    RTC_LOG(LS_WARNING) << "SlideGenerator::ChangeResolution not implemented";
   }
+  Resolution GetResolution() const override;
+
+  absl::optional<int> fps() const override { return absl::nullopt; }
 
  private:
   // Generates some randomly sized and colored squares scattered
@@ -134,8 +180,12 @@ class ScrollingImageFrameGenerator : public FrameGeneratorInterface {
 
   VideoFrameData NextFrame() override;
   void ChangeResolution(size_t width, size_t height) override {
-    RTC_NOTREACHED();
+    RTC_LOG(LS_WARNING)
+        << "ScrollingImageFrameGenerator::ChangeResolution not implemented";
   }
+  Resolution GetResolution() const override;
+
+  absl::optional<int> fps() const override { return absl::nullopt; }
 
  private:
   void UpdateSourceFrame(size_t frame_num);

--- a/deps/libwebrtc/test/frame_generator_capturer.h
+++ b/deps/libwebrtc/test/frame_generator_capturer.h
@@ -66,7 +66,7 @@ struct FrameGeneratorCapturerConfig {
     int framerate = 30;
     TimeDelta change_interval = TimeDelta::Seconds(10);
     struct Crop {
-      TimeDelta scroll_duration = TimeDelta::Seconds(0);
+      TimeDelta scroll_duration;
       absl::optional<int> width;
       absl::optional<int> height;
     } crop;

--- a/deps/libwebrtc/test/frame_utils.cc
+++ b/deps/libwebrtc/test/frame_utils.cc
@@ -14,6 +14,7 @@
 #include <string.h>
 
 #include "api/video/i420_buffer.h"
+#include "api/video/nv12_buffer.h"
 #include "api/video/video_frame.h"
 
 namespace webrtc {
@@ -83,6 +84,18 @@ rtc::scoped_refptr<I420Buffer> ReadI420Buffer(int width, int height, FILE* f) {
   if (fread(buffer->MutableDataU(), 1, size_uv, f) < size_uv)
     return nullptr;
   if (fread(buffer->MutableDataV(), 1, size_uv, f) < size_uv)
+    return nullptr;
+  return buffer;
+}
+
+rtc::scoped_refptr<NV12Buffer> ReadNV12Buffer(int width, int height, FILE* f) {
+  rtc::scoped_refptr<NV12Buffer> buffer(NV12Buffer::Create(width, height));
+  size_t size_y = static_cast<size_t>(width) * height;
+  size_t size_uv = static_cast<size_t>(width + width % 2) * ((height + 1) / 2);
+
+  if (fread(buffer->MutableDataY(), 1, size_y, f) < size_y)
+    return nullptr;
+  if (fread(buffer->MutableDataUV(), 1, size_uv, f) < size_uv)
     return nullptr;
   return buffer;
 }

--- a/deps/libwebrtc/test/frame_utils.h
+++ b/deps/libwebrtc/test/frame_utils.h
@@ -13,6 +13,7 @@
 #include <stdint.h>
 
 #include "api/scoped_refptr.h"
+#include "api/video/nv12_buffer.h"
 
 namespace webrtc {
 class I420Buffer;
@@ -41,6 +42,8 @@ bool FrameBufsEqual(const rtc::scoped_refptr<webrtc::VideoFrameBuffer>& f1,
                     const rtc::scoped_refptr<webrtc::VideoFrameBuffer>& f2);
 
 rtc::scoped_refptr<I420Buffer> ReadI420Buffer(int width, int height, FILE*);
+
+rtc::scoped_refptr<NV12Buffer> ReadNV12Buffer(int width, int height, FILE*);
 
 }  // namespace test
 }  // namespace webrtc

--- a/deps/libwebrtc/test/testsupport/file_utils.cc
+++ b/deps/libwebrtc/test/testsupport/file_utils.cc
@@ -106,7 +106,7 @@ std::string TempFilename(const std::string& dir, const std::string& prefix) {
   if (::GetTempFileNameW(rtc::ToUtf16(dir).c_str(),
                          rtc::ToUtf16(prefix).c_str(), 0, filename) != 0)
     return rtc::ToUtf8(filename);
-  RTC_NOTREACHED();
+  RTC_DCHECK_NOTREACHED();
   return "";
 #else
   int len = dir.size() + prefix.size() + 2 + 6;
@@ -115,7 +115,7 @@ std::string TempFilename(const std::string& dir, const std::string& prefix) {
   snprintf(tempname.get(), len, "%s/%sXXXXXX", dir.c_str(), prefix.c_str());
   int fd = ::mkstemp(tempname.get());
   if (fd == -1) {
-    RTC_NOTREACHED();
+    RTC_DCHECK_NOTREACHED();
     return "";
   } else {
     ::close(fd);

--- a/deps/libwebrtc/test/testsupport/file_utils_override.cc
+++ b/deps/libwebrtc/test/testsupport/file_utils_override.cc
@@ -91,7 +91,7 @@ absl::optional<std::string> ProjectRootPath() {
   char buf[PATH_MAX];
   ssize_t count = ::readlink("/proc/self/exe", buf, arraysize(buf));
   if (count <= 0) {
-    RTC_NOTREACHED() << "Unable to resolve /proc/self/exe.";
+    RTC_DCHECK_NOTREACHED() << "Unable to resolve /proc/self/exe.";
     return absl::nullopt;
   }
   // On POSIX, tests execute in out/Whatever, so src is two levels up.

--- a/deps/libwebrtc/test/testsupport/ivf_video_frame_generator.cc
+++ b/deps/libwebrtc/test/testsupport/ivf_video_frame_generator.cc
@@ -16,6 +16,7 @@
 #include "api/video/i420_buffer.h"
 #include "api/video_codecs/video_codec.h"
 #include "media/base/media_constants.h"
+#include "modules/video_coding/codecs/av1/dav1d_decoder.h"
 #include "modules/video_coding/codecs/h264/include/h264.h"
 #include "modules/video_coding/codecs/vp8/include/vp8.h"
 #include "modules/video_coding/codecs/vp9/include/vp9.h"
@@ -27,7 +28,7 @@ namespace webrtc {
 namespace test {
 namespace {
 
-constexpr int kMaxNextFrameWaitTemeoutMs = 1000;
+constexpr TimeDelta kMaxNextFrameWaitTimeout = TimeDelta::Seconds(1);
 
 }  // namespace
 
@@ -38,19 +39,17 @@ IvfVideoFrameGenerator::IvfVideoFrameGenerator(const std::string& file_name)
       width_(file_reader_->GetFrameWidth()),
       height_(file_reader_->GetFrameHeight()) {
   RTC_CHECK(video_decoder_) << "No decoder found for file's video codec type";
-  VideoCodec codec_settings;
-  codec_settings.codecType = file_reader_->GetVideoCodecType();
-  codec_settings.width = file_reader_->GetFrameWidth();
-  codec_settings.height = file_reader_->GetFrameHeight();
+  VideoDecoder::Settings decoder_settings;
+  decoder_settings.set_codec_type(file_reader_->GetVideoCodecType());
+  decoder_settings.set_max_render_resolution(
+      {file_reader_->GetFrameWidth(), file_reader_->GetFrameHeight()});
   // Set buffer pool size to max value to ensure that if users of generator,
   // ex. test frameworks, will retain frames for quite a long time, decoder
   // won't crash with buffers pool overflow error.
-  codec_settings.buffer_pool_size = std::numeric_limits<int>::max();
+  decoder_settings.set_buffer_pool_size(std::numeric_limits<int>::max());
   RTC_CHECK_EQ(video_decoder_->RegisterDecodeCompleteCallback(&callback_),
                WEBRTC_VIDEO_CODEC_OK);
-  RTC_CHECK_EQ(
-      video_decoder_->InitDecode(&codec_settings, /*number_of_cores=*/1),
-      WEBRTC_VIDEO_CODEC_OK);
+  RTC_CHECK(video_decoder_->Configure(decoder_settings));
 }
 IvfVideoFrameGenerator::~IvfVideoFrameGenerator() {
   MutexLock lock(&lock_);
@@ -80,11 +79,10 @@ FrameGeneratorInterface::VideoFrameData IvfVideoFrameGenerator::NextFrame() {
   RTC_CHECK(image);
   // Last parameter is undocumented and there is no usage of it found.
   RTC_CHECK_EQ(WEBRTC_VIDEO_CODEC_OK,
-               video_decoder_->Decode(*image, /*missing_frames=*/false,
-                                      /*render_time_ms=*/0));
-  bool decoded = next_frame_decoded_.Wait(kMaxNextFrameWaitTemeoutMs);
+               video_decoder_->Decode(*image, /*render_time_ms=*/0));
+  bool decoded = next_frame_decoded_.Wait(kMaxNextFrameWaitTimeout);
   RTC_CHECK(decoded) << "Failed to decode next frame in "
-                     << kMaxNextFrameWaitTemeoutMs << "ms. Can't continue";
+                     << kMaxNextFrameWaitTimeout << ". Can't continue";
 
   MutexLock frame_lock(&frame_decode_lock_);
   rtc::scoped_refptr<VideoFrameBuffer> buffer =
@@ -105,6 +103,11 @@ void IvfVideoFrameGenerator::ChangeResolution(size_t width, size_t height) {
   MutexLock lock(&lock_);
   width_ = width;
   height_ = height;
+}
+
+FrameGeneratorInterface::Resolution IvfVideoFrameGenerator::GetResolution()
+    const {
+  return {.width = width_, .height = height_};
 }
 
 int32_t IvfVideoFrameGenerator::DecodedCallback::Decoded(
@@ -141,6 +144,12 @@ std::unique_ptr<VideoDecoder> IvfVideoFrameGenerator::CreateVideoDecoder(
   }
   if (codec_type == VideoCodecType::kVideoCodecH264) {
     return H264Decoder::Create();
+  }
+  if (codec_type == VideoCodecType::kVideoCodecAV1) {
+    return CreateDav1dDecoder();
+  }
+  if (codec_type == VideoCodecType::kVideoCodecH265) {
+    // TODO(bugs.webrtc.org/13485): implement H265 decoder
   }
   return nullptr;
 }

--- a/deps/libwebrtc/test/testsupport/ivf_video_frame_generator.h
+++ b/deps/libwebrtc/test/testsupport/ivf_video_frame_generator.h
@@ -35,6 +35,9 @@ class IvfVideoFrameGenerator : public FrameGeneratorInterface {
 
   VideoFrameData NextFrame() override;
   void ChangeResolution(size_t width, size_t height) override;
+  Resolution GetResolution() const override;
+
+  absl::optional<int> fps() const override { return absl::nullopt; }
 
  private:
   class DecodedCallback : public DecodedImageCallback {

--- a/src/Broadcaster.cpp
+++ b/src/Broadcaster.cpp
@@ -439,7 +439,7 @@ void Broadcaster::CreateSendTransport(bool enableAudio, bool useSimulcast)
 		};
 		/* clang-format on */
 
-		this->sendTransport->Produce(this, audioTrack, nullptr, &codecOptions, nullptr);
+		this->sendTransport->Produce(this, audioTrack.get(), nullptr, &codecOptions, nullptr);
 	}
 	else
 	{
@@ -459,11 +459,11 @@ void Broadcaster::CreateSendTransport(bool enableAudio, bool useSimulcast)
 			encodings.emplace_back(webrtc::RtpEncodingParameters());
 			encodings.emplace_back(webrtc::RtpEncodingParameters());
 
-			this->sendTransport->Produce(this, videoTrack, &encodings, nullptr, nullptr);
+			this->sendTransport->Produce(this, videoTrack.get(), &encodings, nullptr, nullptr);
 		}
 		else
 		{
-			this->sendTransport->Produce(this, videoTrack, nullptr, nullptr, nullptr);
+			this->sendTransport->Produce(this, videoTrack.get(), nullptr, nullptr, nullptr);
 		}
 	}
 	else

--- a/src/MediaStreamTrackFactory.cpp
+++ b/src/MediaStreamTrackFactory.cpp
@@ -7,12 +7,26 @@
 #include "pc/test/fake_audio_capture_module.h"
 #include "pc/test/fake_periodic_video_track_source.h"
 #include "pc/test/frame_generator_capturer_video_track_source.h"
+#include "pc/test/fake_video_track_source.h"
 #include "system_wrappers/include/clock.h"
 #include "api/audio_codecs/builtin_audio_decoder_factory.h"
 #include "api/audio_codecs/builtin_audio_encoder_factory.h"
 #include "api/create_peerconnection_factory.h"
 #include "api/video_codecs/builtin_video_decoder_factory.h"
 #include "api/video_codecs/builtin_video_encoder_factory.h"
+
+#include "api/video_codecs/video_decoder_factory.h"
+#include "api/video_codecs/video_decoder_factory_template.h"
+#include "api/video_codecs/video_decoder_factory_template_dav1d_adapter.h"
+#include "api/video_codecs/video_decoder_factory_template_libvpx_vp8_adapter.h"
+#include "api/video_codecs/video_decoder_factory_template_libvpx_vp9_adapter.h"
+#include "api/video_codecs/video_decoder_factory_template_open_h264_adapter.h"
+#include "api/video_codecs/video_encoder_factory.h"
+#include "api/video_codecs/video_encoder_factory_template.h"
+#include "api/video_codecs/video_encoder_factory_template_libaom_av1_adapter.h"
+#include "api/video_codecs/video_encoder_factory_template_libvpx_vp8_adapter.h"
+#include "api/video_codecs/video_encoder_factory_template_libvpx_vp9_adapter.h"
+#include "api/video_codecs/video_encoder_factory_template_open_h264_adapter.h"
 
 using namespace mediasoupclient;
 
@@ -21,21 +35,23 @@ static rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> factory;
 /* MediaStreamTrack holds reference to the threads of the PeerConnectionFactory.
  * Use plain pointers in order to avoid threads being destructed before tracks.
  */
-static rtc::Thread* networkThread;
-static rtc::Thread* signalingThread;
-static rtc::Thread* workerThread;
+// static rtc::Thread* networkThread;
+// static rtc::Thread* signalingThread;
+  std::unique_ptr<rtc::Thread> signalingThread;
+// static rtc::Thread* workerThread;
 
 static void createFactory()
 {
-	networkThread   = rtc::Thread::Create().release();
-	signalingThread = rtc::Thread::Create().release();
-	workerThread    = rtc::Thread::Create().release();
+	// networkThread   = rtc::Thread::Create().release();
+	signalingThread = rtc::Thread::CreateWithSocketServer();
+	// workerThread    = rtc::Thread::Create().release();
 
-	networkThread->SetName("network_thread", nullptr);
+	// networkThread->SetName("network_thread", nullptr);
 	signalingThread->SetName("signaling_thread", nullptr);
-	workerThread->SetName("worker_thread", nullptr);
+	// workerThread->SetName("worker_thread", nullptr);
 
-	if (!networkThread->Start() || !signalingThread->Start() || !workerThread->Start())
+	// if (!networkThread->Start() || !signalingThread->Start() || !workerThread->Start())
+	if(!signalingThread->Start())
 	{
 		MSC_THROW_INVALID_STATE_ERROR("thread start errored");
 	}
@@ -49,14 +65,24 @@ static void createFactory()
 	}
 
 	factory = webrtc::CreatePeerConnectionFactory(
-	  networkThread,
-	  workerThread,
-	  signalingThread,
+	  nullptr,
+	  nullptr,
+	  signalingThread.get(),
 	  fakeAudioCaptureModule,
 	  webrtc::CreateBuiltinAudioEncoderFactory(),
 	  webrtc::CreateBuiltinAudioDecoderFactory(),
-	  webrtc::CreateBuiltinVideoEncoderFactory(),
-	  webrtc::CreateBuiltinVideoDecoderFactory(),
+	//   webrtc::CreateBuiltinVideoEncoderFactory(),
+	//   webrtc::CreateBuiltinVideoDecoderFactory(),
+      std::make_unique<webrtc::VideoEncoderFactoryTemplate<
+          webrtc::LibvpxVp8EncoderTemplateAdapter,
+          webrtc::LibvpxVp9EncoderTemplateAdapter,
+          webrtc::OpenH264EncoderTemplateAdapter,
+          webrtc::LibaomAv1EncoderTemplateAdapter>>(),
+      std::make_unique<webrtc::VideoDecoderFactoryTemplate<
+          webrtc::LibvpxVp8DecoderTemplateAdapter,
+          webrtc::LibvpxVp9DecoderTemplateAdapter,
+          webrtc::OpenH264DecoderTemplateAdapter,
+          webrtc::Dav1dDecoderTemplateAdapter>>(),
 	  nullptr /*audio_mixer*/,
 	  nullptr /*audio_processing*/);
 
@@ -77,7 +103,7 @@ rtc::scoped_refptr<webrtc::AudioTrackInterface> createAudioTrack(const std::stri
 
 	rtc::scoped_refptr<webrtc::AudioSourceInterface> source = factory->CreateAudioSource(options);
 
-	return factory->CreateAudioTrack(label, source);
+	return factory->CreateAudioTrack(label, source.get());
 }
 
 // Video track creation.
@@ -98,10 +124,11 @@ rtc::scoped_refptr<webrtc::VideoTrackInterface> createSquaresVideoTrack(const st
 		createFactory();
 
 	std::cout << "[INFO] getting frame generator" << std::endl;
-	auto* videoTrackSource = new rtc::RefCountedObject<webrtc::FrameGeneratorCapturerVideoTrackSource>(
+	auto videoTrackSource = rtc::make_ref_counted<webrtc::FrameGeneratorCapturerVideoTrackSource>(
 	  webrtc::FrameGeneratorCapturerVideoTrackSource::Config(), webrtc::Clock::GetRealTimeClock(), false);
-	videoTrackSource->Start();
+	// videoTrackSource->Start();
 
 	std::cout << "[INFO] creating video track" << std::endl;
-	return factory->CreateVideoTrack(rtc::CreateRandomUuid(), videoTrackSource);
+	return factory->CreateVideoTrack(videoTrackSource, rtc::CreateRandomUuid());
+	// return factory->CreateVideoTrack(webrtc::FakeVideoTrackSource::Create(), rtc::CreateRandomUuid());
 }


### PR DESCRIPTION
I've upgraded `libmediasoupclient` to WebRTC m120-6099 and also updated the corresponding test demo, `mediasoup-broadcaster-demo`, to the same version. 

This upgrade allows for successful room entry and video stream publishing. 

Testing on a Mac with an M3 Max chip has been successful.